### PR TITLE
Add generics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@
 
 all: vet lint build install
 
-build clean install lint run vet:
+build clean install lint lintall run vet:
 	$(MAKE) -C kubectl-plugins/kubectl-n $@

--- a/kubectl-plugins/kubectl-n/Makefile
+++ b/kubectl-plugins/kubectl-n/Makefile
@@ -19,6 +19,9 @@ install:
 lint:
 	golangci-lint run
 
+lintall:
+	golangci-lint run --enable-all
+
 run: build
 	./${BINARY_NAME}-${ARCH}
 


### PR DESCRIPTION
Define a tableFormatter interface for table row structs to implement.

Have the getTitleRow() method return the new interface instead of tableRow.

In getTitleRow(), call reflect.ValueOf(&row).Elem() once outside of the loop.

Convert the table struct to use generics to work with any structure that implements the new tableFormatter interface, and adjust its methods too.

Move the slices.SortFunc out of the table write() method back into the mainline since its comparisons are specific to the tableRow structure and not generic structs.

In the mainline make the generic type used by table to be a pointer since that is required for the generics to work since the new interface is implemented on *tableRow not tableRow.

Add a lintall option to the Makefiles