### PR TITLE
Minor improvements

### DIFF
--- a/kubectl-plugins/kubectl-n/main.go
+++ b/kubectl-plugins/kubectl-n/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"cmp"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -22,7 +23,6 @@ import (
 
 const tick = "\u2713"
 
-// Is there a better way than defining this as a global var?
 var goodStatuses = map[v1.NodeConditionType]v1.ConditionStatus{
 	"CorruptDockerOverlay2": "False",
 	"DiskPressure":          "False",
@@ -49,12 +49,12 @@ type tableRow struct {
 	InstanceGroup string `title:"INSTANCE-GROUP,omitempty"`
 }
 
-// Implement the texttab.tableFormatter interface.
+// Implement the texttab.TableFormatter interface.
 func (tr *tableRow) TabTitleRow() string {
 	return texttable.ReflectedTitleRow(tr)
 }
 
-// Implement the texttab.tableFormatter interface.
+// Implement the texttab.TableFormatter interface.
 func (tr *tableRow) TabValues() string {
 	return texttable.ReflectedTabValues(tr)
 }
@@ -68,10 +68,12 @@ func main() {
 
 	nodes, err := k8s.ListNodes(clientset)
 	if err != nil {
-		panic(err.Error())
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(1)
 	}
 	if len(nodes.Items) == 0 {
-		panic("No nodes found")
+		fmt.Fprintf(os.Stderr, "No nodes found")
+		os.Exit(1)
 	}
 
 	var tbl texttable.Table[*tableRow]

--- a/texttable/texttable.go
+++ b/texttable/texttable.go
@@ -21,12 +21,12 @@ const (
 
 // Interface that a table row struct needs to implement for the table.Write() method to be able to use it.
 // Both of these methods need to return a string containing tab separated row values for the tabwriter module to use.
-type tableFormatter interface {
+type TableFormatter interface {
 	TabTitleRow() string
 	TabValues() string
 }
 
-type Table[R tableFormatter] struct {
+type Table[R TableFormatter] struct {
 	Rows []R
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	numSecondsPerWeek   = 60 * 60 * 24 * 7
-	numSecondsPerDay    = 60 * 60 * 24
-	numSecondsPerHour   = 60 * 60
 	numSecondsPerMinute = 60
+	numSecondsPerHour   = 60 * numSecondsPerMinute
+	numSecondsPerDay    = 24 * numSecondsPerHour
+	numSecondsPerWeek   = 7 * numSecondsPerDay
 )
 
 // Return the age in a human readable format of the first 2 non-zero time units from weeks to seconds,


### PR DESCRIPTION
Interfaces should probably be public/exported so rename `tableFormatter` to `TableFormatter`.

Update the `numSecondsPer*` constancts in the `util` package to build upon each other.

Replace the `panic` call in the main `kubectl-n` application with writing the error to stderr and using os.Exit(1) instead.