### PR TITLE
Add kubectl-p plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 kubectl-plugins/kubectl-n/kubectl-n*
+kubectl-plugins/kubectl-n/kubectl-p*

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ all: vet lint build install
 
 build clean install run:
 	$(MAKE) -C kubectl-plugins/kubectl-n $@
+	$(MAKE) -C kubectl-plugins/kubectl-p $@
 
 lint lintall vet:
 	$(MAKE) -C k8s $@
 	$(MAKE) -C kubectl-plugins/kubectl-n $@
+	$(MAKE) -C kubectl-plugins/kubectl-p $@
 	$(MAKE) -C texttable $@
 	$(MAKE) -C util $@

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1,6 +1,3 @@
-ARCH := $(shell uname -s | tr '[A-Z]' '[a-z]')
-BINARY_NAME=kubectl-n
-
 .PHONY: all lint lintall vet
 
 all: vet lint

--- a/kubectl-plugins/kubectl-p/Makefile
+++ b/kubectl-plugins/kubectl-p/Makefile
@@ -1,0 +1,29 @@
+ARCH := $(shell uname -s | tr '[A-Z]' '[a-z]')
+BINARY_NAME=kubectl-p
+
+.PHONY: all build clean install lint run vet
+
+all: vet lint build install
+
+build:
+	GOARCH=amd64 GOOS=darwin go build -o ${BINARY_NAME}-darwin -race main.go
+	GOARCH=amd64 GOOS=linux go build -o ${BINARY_NAME}-linux -race main.go
+
+clean:
+	go clean
+	rm -f ${BINARY_NAME}-darwin ${BINARY_NAME}-linux
+
+install:
+	go install -ldflags='-s'
+
+lint:
+	golangci-lint run
+
+lintall:
+	golangci-lint run --enable-all
+
+run: build
+	./${BINARY_NAME}-${ARCH}
+
+vet:
+	go vet

--- a/kubectl-plugins/kubectl-p/main.go
+++ b/kubectl-plugins/kubectl-p/main.go
@@ -1,0 +1,129 @@
+/*
+A kubectl plugin to implement the 'kubectl p' command when placed in your PATH.
+
+This is a bit like 'kubectl get pods -o wide' but shows columns with more detail on the node and AWS availability zone.
+*/
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+
+	"github.com/jim-barber-he/go/k8s"
+	"github.com/jim-barber-he/go/texttable"
+	"github.com/jim-barber-he/go/util"
+
+	flag "github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+)
+
+const tick = "\u2713"
+
+type tableRow struct {
+	Namespace string `title:"NAMESPACE,omitempty"`
+	Name      string `title:"NAME"`
+	Ready     string `title:"READY"`
+	Status    string `title:"STATUS"`
+	Restarts  string `title:"RESTARTS"`
+	Age       string `title:"AGE"`
+	IP        string `title:"IP"`
+	Node      string `title:"NODE"`
+	Spot      string `title:"SPOT"`
+	AZ        string `title:"AZ,omitempty"`
+}
+
+// Implement the texttab.TableFormatter interface.
+func (tr *tableRow) TabTitleRow() string {
+	return texttable.ReflectedTitleRow(tr)
+}
+
+// Implement the texttab.TableFormatter interface.
+func (tr *tableRow) TabValues() string {
+	return texttable.ReflectedTabValues(tr)
+}
+
+func main() {
+	var allNamespaces bool
+	var kubeContext string
+	var labelSelector string
+
+	flag.BoolVarP(&allNamespaces, "all-namespaces", "A", false, "List the pods across all namespaces")
+	flag.StringVar(&kubeContext, "context", "", "The name of the kubeconfig context to use")
+	flag.StringVarP(&labelSelector, "selector", "l", "", "Selector (label query) to filter on")
+
+	flag.Parse()
+
+	clientset := k8s.Client(kubeContext)
+
+	namespace := ""
+	if !allNamespaces {
+		namespace = k8s.Namespace(kubeContext)
+	}
+
+	pods, err := k8s.ListPods(clientset, namespace, labelSelector)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(1)
+	}
+	if len(pods.Items) == 0 {
+		fmt.Fprintf(os.Stderr, "No pods found")
+		os.Exit(1)
+	}
+
+	var tbl texttable.Table[*tableRow]
+	nodes := make(map[string]*v1.Node)
+	for _, pod := range pods.Items {
+		var row tableRow
+
+		// Find out what node the pod is on and get its details if we haven't already.
+		node := pod.Spec.NodeName
+		if _, ok := nodes[node]; !ok {
+			nodes[node], err = k8s.GetNode(clientset, node)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s", err)
+				os.Exit(1)
+			}
+		}
+		numContainers := len(pod.Status.ContainerStatuses)
+		numReady := 0
+		restarts := 0
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.Ready {
+				numReady++
+			}
+			if containerStatus.RestartCount > 0 {
+				restarts += int(containerStatus.RestartCount)
+			}
+		}
+
+		if allNamespaces {
+			row.Namespace = pod.Namespace
+		}
+		row.Name = pod.Name
+		row.Ready = fmt.Sprintf("%d/%d", numReady, numContainers)
+		row.Status = string(pod.Status.Phase)
+		row.Restarts = strconv.Itoa(restarts)
+		row.Age = util.FormatAge(pod.CreationTimestamp.Time)
+		row.IP = pod.Status.PodIP
+		row.Node = node
+		if nodes[node].Labels["node-role.kubernetes.io/spot-worker"] != "" {
+			row.Spot = tick
+		} else {
+			row.Spot = "x"
+		}
+		row.AZ = util.LastSplitItem(nodes[node].Labels["topology.kubernetes.io/zone"], "")
+
+		tbl.Append(&row)
+	}
+
+	// Sort function to sort the rows slice by Name when iterating through it.
+	slices.SortFunc(tbl.Rows, func(a, b *tableRow) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	// Display the table.
+	tbl.Write()
+}

--- a/texttable/Makefile
+++ b/texttable/Makefile
@@ -1,6 +1,3 @@
-ARCH := $(shell uname -s | tr '[A-Z]' '[a-z]')
-BINARY_NAME=kubectl-n
-
 .PHONY: all lint lintall vet
 
 all: vet lint

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,6 +1,3 @@
-ARCH := $(shell uname -s | tr '[A-Z]' '[a-z]')
-BINARY_NAME=kubectl-n
-
 .PHONY: all lint lintall vet
 
 all: vet lint


### PR DESCRIPTION
Add new `kubectl-p` plugin to list pods showing details about if they are on a spot instance and what availability zone they are in.

Add new `GetNode()`, `KubeConfig()`, `ListPods()`, and `Namespace()` methods to the `k8s` package.

Clean up the Makefiles for the modules which hand unnecessary `ARCH` and `BINARY_NAME` values set.