### PR TITLE
More changes

### DIFF
--- a/kubectl-plugins/kubectl-n/main.go
+++ b/kubectl-plugins/kubectl-n/main.go
@@ -9,14 +9,13 @@ package main
 import (
 	"cmp"
 	"fmt"
-	"os"
+	"log"
 	"slices"
 	"strings"
 
 	"github.com/jim-barber-he/go/k8s"
 	"github.com/jim-barber-he/go/texttable"
 	"github.com/jim-barber-he/go/util"
-
 	flag "github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 )
@@ -60,20 +59,17 @@ func (tr *tableRow) TabValues() string {
 }
 
 func main() {
-	var kubeContext string
-	flag.StringVar(&kubeContext, "context", "", "The name of the kubeconfig context to use")
+	kubeContext := flag.String("context", "", "The name of the kubeconfig context to use")
 	flag.Parse()
 
-	clientset := k8s.Client(kubeContext)
+	clientset := k8s.Client(*kubeContext)
 
 	nodes, err := k8s.ListNodes(clientset)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 	if len(nodes.Items) == 0 {
-		fmt.Fprintf(os.Stderr, "No nodes found")
-		os.Exit(1)
+		log.Fatal("No nodes found")
 	}
 
 	var tbl texttable.Table[*tableRow]
@@ -156,7 +152,7 @@ func getNodeStatus(conditions []v1.NodeCondition) (string, []string) {
 	status := tick
 	for _, condition := range conditions {
 		if _, ok := goodStatuses[condition.Type]; !ok {
-			fmt.Printf("Warning, we haven't covered all conditions - Please add %s to goodStatuses", condition.Type)
+			log.Printf("Warning, we haven't covered all conditions - Please add %s to goodStatuses", condition.Type)
 			continue
 		}
 		if condition.Status != goodStatuses[condition.Type] {

--- a/util/util.go
+++ b/util/util.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
@@ -16,7 +17,7 @@ const (
 	numSecondsPerWeek   = 7 * numSecondsPerDay
 )
 
-// Return the age in a human readable format of the first 2 non-zero time units from weeks to seconds,
+// FormatAge returns the age in a human readable format of the first 2 non-zero time units from weeks to seconds,
 // or just the seconds if no higher time unit was above 0.
 // This differs from duration.String() in that it also handles weeks and days.
 func FormatAge(timestamp time.Time) string {
@@ -69,11 +70,17 @@ func FormatAge(timestamp time.Time) string {
 	return fmt.Sprintf("%s%ds", dateStr, seconds)
 }
 
-// LastSplitItem() splits a string into a slice based on a split character and returns the last item.
+// LastSplitItem splits a string into a slice based on a split character and returns the last item.
 func LastSplitItem(str, splitChar string) string {
 	result := strings.Split(str, splitChar)
 	if len(result) > 0 {
 		return result[len(result)-1]
 	}
 	return ""
+}
+
+// TimeTaken is designed to be called via a defer statement to show elapsed time for things like functions/methods.
+// e.g. put something like the this at the top of your function: `defer util.TimeTaken(time.Now(), "functionName")`.
+func TimeTaken(start time.Time, name string) {
+	fmt.Fprintf(os.Stderr, "%s took %s\n", name, time.Since(start))
 }


### PR DESCRIPTION
kubectl-p wasn't outputting the pod statuses in the same format as kubectl.
I looked at the kubectl code and it uses a printPod function. Since that isn't public I needed to copy it, removing parts I don't need to create a PodDetails function as supporting functions. Use the new PodDetails function to get the details I need in kubectl-p.

Change how pflags is used so that I don't have to declare all the variables first.

Add the ability to use CPU and Memory profiling in kubectl-p.

Add a TimeTaken function to the util package. I used this to help me track down where all my time was going in kubectl-p.

Calling k8s.GetNode for each node separately was slow as each call could be up to 200ms. Calling k8s.ListNodes once at the start is much faster, reducing the runtime by over 4 seconds (to just over 1 second in total).

Use log.Fatal in place of fmt.Print* followed by os.Exit

Replace os.Exit in mainline of kubectl-p with return statements so that defer statements will run upon exit.