### PR TITLE
Cleanups and improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_size = tab
+indent_style = tab
+max_line_length = 120
+tab_width = 8
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = 120

--- a/aws/Makefile
+++ b/aws/Makefile
@@ -6,7 +6,7 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
 
 vet:
 	go vet

--- a/aws/errors.go
+++ b/aws/errors.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jim-barber-he/go/util"
+)
+
+// NewCreateDirError creates a new error for directory creation failure.
+func NewCreateDirError(directory string) error {
+	return &util.Error{
+		Msg:   "failed to create directory: ",
+		Param: directory,
+	}
+}
+
+// NewOneParameterError creates a new error for invalid parameter count.
+func NewOneParameterError(numParameters int) error {
+	return &util.Error{
+		Msg:   "failed to validate parameters: ",
+		Param: fmt.Sprintf("expected 1 parameter, got %d", numParameters),
+	}
+}
+
+// NewParameterDeleteError creates a new error for parameter deletion failure.
+func NewParameterDeleteError(parameter string) error {
+	return &util.Error{
+		Msg:   "failed to delete parameter: ",
+		Param: parameter,
+	}
+}
+
+// NewParameterDescribeError creates a new error for parameter description failure.
+func NewParameterDescribeError(parameter string) error {
+	return &util.Error{
+		Msg:   "failed to describe parameter: ",
+		Param: parameter,
+	}
+}
+
+// NewParameterGetError creates a new error for parameter retrieval failure.
+func NewParameterGetError(parameter string) error {
+	return &util.Error{
+		Msg:   "failed to get parameter: ",
+		Param: parameter,
+	}
+}
+
+// NewParameterPutError creates a new error for parameter storage failure.
+func NewParameterPutError(parameter string) error {
+	return &util.Error{
+		Msg:   "failed to put parameter: ",
+		Param: parameter,
+	}
+}
+
+// NewWriteCacheFileError creates a new error for failure to write to the cache file.
+func NewWriteCacheFileError(file string) error {
+	return &util.Error{
+		Msg:   "failed to write cache file: ",
+		Param: file,
+	}
+}
+
+var (
+	errGetCachePath       = errors.New("failed to get cache file path")
+	errGetClientName      = errors.New("failed to get client name")
+	errGetToken           = errors.New("failed to get token")
+	errMarshalJSON        = errors.New("failed to marshal cache data to JSON")
+	errOpenBrowser        = errors.New("failed to open browser for authentication")
+	errOSUserNotFound     = errors.New("failed to find OS user")
+	errParameterGetByPath = errors.New("failed to get parameters by path")
+	errRegisterClient     = errors.New("failed to register client")
+	errSSOTimeout         = errors.New("SSO login attempt timed out")
+	errStartDeviceAuth    = errors.New("failed to start device authorisation")
+	errWriteCacheFile     = errors.New("failed to write cache file")
+)

--- a/golock/Makefile
+++ b/golock/Makefile
@@ -20,7 +20,7 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
 
 run: build
 	./${BINARY_NAME}-${ARCH}

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -6,7 +6,10 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
+
+test:
+	go test
 
 vet:
 	go vet

--- a/kubectl-plugins/kubectl-n/Makefile
+++ b/kubectl-plugins/kubectl-n/Makefile
@@ -20,10 +20,13 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
 
 run: build
 	./${BINARY_NAME}-${ARCH}
+
+test:
+	go test
 
 vet:
 	go vet

--- a/kubectl-plugins/kubectl-p/Makefile
+++ b/kubectl-plugins/kubectl-p/Makefile
@@ -20,10 +20,13 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
 
 run: build
 	./${BINARY_NAME}-${ARCH}
+
+test:
+	go test
 
 vet:
 	go vet

--- a/ssm/Makefile
+++ b/ssm/Makefile
@@ -20,7 +20,7 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
 
 run: build
 	./${BINARY_NAME}-${ARCH}

--- a/ssm/cmd/delete.go
+++ b/ssm/cmd/delete.go
@@ -25,21 +25,26 @@ var deleteCmd = &cobra.Command{
 	},
 	SilenceErrors: true,
 	ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
-		var completionHelp []string
-		switch {
-		case len(args) == 0:
-			completionHelp = cobra.AppendActiveHelp(completionHelp, "dev, test*, or prod*")
-		case len(args) == 1:
-			completionHelp = cobra.AppendActiveHelp(completionHelp, "The path of the SSM parameter")
-		default:
-			completionHelp = cobra.AppendActiveHelp(completionHelp, "No more arguments")
-		}
-		return completionHelp, cobra.ShellCompDirectiveNoFileComp
+		return deleteCompletionHelp(args)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
+}
+
+// deleteCompletionHelp provides shell completion help for the delete command.
+func deleteCompletionHelp(args []string) ([]string, cobra.ShellCompDirective) {
+	var completionHelp []string
+	switch {
+	case len(args) == 0:
+		completionHelp = cobra.AppendActiveHelp(completionHelp, "dev, test*, or prod*")
+	case len(args) == 1:
+		completionHelp = cobra.AppendActiveHelp(completionHelp, "The path of the SSM parameter")
+	default:
+		completionHelp = cobra.AppendActiveHelp(completionHelp, "No more arguments")
+	}
+	return completionHelp, cobra.ShellCompDirectiveNoFileComp
 }
 
 // doDelete deletes a parameter from the SSM parameter store.

--- a/ssm/cmd/errors.go
+++ b/ssm/cmd/errors.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/jim-barber-he/go/util"
+)
+
+var (
+	errGetSSMParameter   = errors.New("failed to get SSM parameter")
+	errPutSSMParameter   = errors.New("failed to put SSM parameter")
+	errListSSMParameters = errors.New("failed to list SSM parameters")
+	errReadFile          = errors.New("failed to read file")
+	errValueRequired     = errors.New("VALUE is required when --file is not used")
+	errValueWithFile     = errors.New("VALUE should not be provided when --file is used")
+)
+
+// NewBriefAndFullError creates a new error for when the --brief and --full options are both specified.
+func NewBriefAndFullError(usage string) error {
+	return &util.Error{
+		Msg:   "it does not make sense to specify both --brief and --full\n",
+		Param: usage,
+	}
+}

--- a/ssm/main.go
+++ b/ssm/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 func main() {
+	// Set log flags to 0 to disable timestamp and other prefixes.
 	log.SetFlags(0)
 
 	ctx := context.Background()
 	if err := cmd.Execute(ctx); err != nil {
-		log.Fatalln(err)
+		log.Fatalf("Error executing command: %v", err)
 	}
 }

--- a/texttable/Makefile
+++ b/texttable/Makefile
@@ -6,7 +6,10 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
+
+test:
+	go test
 
 vet:
 	go vet

--- a/texttable/texttable.go
+++ b/texttable/texttable.go
@@ -38,6 +38,10 @@ func (t *Table[R]) Append(r R) {
 
 // Write displays the table to stdout.
 func (t *Table[R]) Write() {
+	if len(t.Rows) == 0 {
+		return
+	}
+
 	tw := tabwriter.NewWriter(os.Stdout, tableMinWidth, tableTabWidth, tablePadding, tablePadChar, tableFlags)
 	fmt.Fprintln(tw, t.Rows[0].TabTitleRow())
 	for _, row := range t.Rows {

--- a/util/Makefile
+++ b/util/Makefile
@@ -6,7 +6,10 @@ lint:
 	golangci-lint run
 
 lintall:
-	golangci-lint run --enable-all
+	golangci-lint run --enable-all || true
+
+test:
+	go test
 
 vet:
 	go vet

--- a/util/errors.go
+++ b/util/errors.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error is a generic type for errors that take a parameter.
+type Error struct {
+	Msg   string
+	Param string
+}
+
+// Error implements the Error interface.
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s%s", e.Msg, e.Param)
+}
+
+var (
+	errCommandTimedOut = errors.New("command timed out")
+	errTerminalSize    = errors.New("failed to get terminal size")
+)


### PR DESCRIPTION
Add improved error handling to everything.
Also improved comments.

Use the `aws.To*` functions in the `/aws/*.go` files rather than using pointers.

Break up long functions in the utilities into multiple smaller functions, making the code cleaner.

Replace some uses on panic by returning errors instead.

In `golock` define a more constants and group them into 3 categories.

Renamed `util.Run()` to `util.RunWithTimeout()`.

Add `make test` targets.

The `make lintall` targets will always return success. That's because not all of the things picked up by it need to be fixed, and not having it exit in error allows me to run it from the top of the tree to cover everything.

Add `.editorconfig`