### PR TITLE
Fix to kubectl-p namespace selection

### DIFF
--- a/kubectl-plugins/kubectl-p/main.go
+++ b/kubectl-plugins/kubectl-p/main.go
@@ -246,6 +246,7 @@ func selectNamespace(clientset *kubernetes.Clientset, opts options) (string, err
 		if _, err := k8s.GetNamespace(clientset, opts.namespace); err != nil {
 			return "", fmt.Errorf("invalid namespace: %w", err)
 		}
+		return opts.namespace, nil
 	}
 
 	return k8s.Namespace(opts.kubeContext), nil


### PR DESCRIPTION
This broke when I refactored the code. Fixed to work again.