### PR TITLE
More improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jim-barber-he/go
 
-go 1.23.2
+go 1.23.3
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1

--- a/kubectl-plugins/kubectl-p/README.md
+++ b/kubectl-plugins/kubectl-p/README.md
@@ -16,6 +16,7 @@ $ kubectl p --help
 ```
 ```
   -A, --all-namespaces       List the pods across all namespaces. Overrides --namespace / -n
+      --grep string          Limit output to pods with names containing this string
       --context string       The name of the kubeconfig context to use
   -n, --namespace string     If present, the namespace scope for this CLI request
       --profile-cpu string   Produce pprof cpu profiling output in supplied file

--- a/ssm/README.md
+++ b/ssm/README.md
@@ -72,7 +72,7 @@ Delete a parameter from the SSM parameter store.
 
 ```
 Usage:
-  ssm delete [flags] ENV PARAM
+  ssm delete [flags] ENVIRONMENT PARAMEMETER
 
 Flags:
   -h, --help   help for delete
@@ -125,8 +125,8 @@ Store a parameter and its value in the AWS SSM parameter store.
 
 ```
 Usage:
-  ssm put [flags] ENV PARAM VALUE
-  ssm put [flags] ENV PARAM --file FILE
+  ssm put [flags] ENVIRONMENT PARAMETER VALUE
+  ssm put [flags] ENVIRONMENT PARAMETER --file FILE
 
 Flags:
   -f, --file string     Get the value from the file contents

--- a/ssm/cmd/delete.go
+++ b/ssm/cmd/delete.go
@@ -16,10 +16,13 @@ var deleteLong = heredoc.Doc(`
 
 // deleteCmd represents the delete command.
 var deleteCmd = &cobra.Command{
-	Use:   "delete [flags] ENV PARAM",
+	Use:   "delete [flags] ENVIRONMENT PARAMETER",
 	Short: "Delete a parameter from the SSM parameter store",
 	Long:  deleteLong,
 	Args:  cobra.ExactArgs(2),
+	PreRunE: func(_ *cobra.Command, args []string) error {
+		return validateEnvironment(args[0])
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return doDelete(cmd.Context(), args)
 	},

--- a/ssm/cmd/errors.go
+++ b/ssm/cmd/errors.go
@@ -15,10 +15,18 @@ var (
 	errValueWithFile     = errors.New("VALUE should not be provided when --file is used")
 )
 
-// NewBriefAndFullError creates a new error for when the --brief and --full options are both specified.
-func NewBriefAndFullError(usage string) error {
+// newBriefAndFullError creates a new error for when the --brief and --full options are both specified.
+func newBriefAndFullError(usage string) error {
 	return &util.Error{
 		Msg:   "it does not make sense to specify both --brief and --full\n",
 		Param: usage,
+	}
+}
+
+// newInvalidEnvError creates a new error for when an invalid environment is specified.
+func newInvalidEnvError(env string) error {
+	return &util.Error{
+		Msg:   "invalid environment: ",
+		Param: env,
 	}
 }

--- a/ssm/cmd/get.go
+++ b/ssm/cmd/get.go
@@ -30,6 +30,9 @@ var (
 		Short: "Retrieve a parameter from the AWS SSM parameter store",
 		Long:  getLong,
 		Args:  cobra.ExactArgs(2),
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			return validateEnvironment(args[0])
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doGet(cmd.Context(), args)
 		},

--- a/ssm/cmd/list.go
+++ b/ssm/cmd/list.go
@@ -43,8 +43,12 @@ var (
 		Short: "List parameters from the SSM parameter store below a supplied path",
 		Long:  listLong,
 		Args:  cobra.RangeArgs(1, 2),
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return validateListOptions(cmd)
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			result := validateListOptions(cmd)
+			if result != nil {
+				return result
+			}
+			return validateEnvironment(args[0])
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doList(cmd.Context(), args)
@@ -86,7 +90,7 @@ func listCompletionHelp(args []string) ([]string, cobra.ShellCompDirective) {
 // validateListOptions validates the list command options.
 func validateListOptions(cmd *cobra.Command) error {
 	if listOpts.brief && listOpts.full {
-		return NewBriefAndFullError(cmd.UsageString())
+		return newBriefAndFullError(cmd.UsageString())
 	}
 	return nil
 }
@@ -138,7 +142,7 @@ func displayListParameters(params []aws.SSMParameter) {
 				fmt.Printf("Error: %s\n", param.Error)
 			}
 		}
-		if i < numParams {
+		if i < numParams && !listOpts.brief {
 			fmt.Println()
 		}
 	}

--- a/ssm/cmd/put.go
+++ b/ssm/cmd/put.go
@@ -34,10 +34,13 @@ var putLong = heredoc.Doc(`
 var (
 	// putCmd represents the put command.
 	putCmd = &cobra.Command{
-		Use:   "put [flags] ENV PARAM VALUE\n  ssm put [flags] ENV PARAM --file FILE",
+		Use:   "put [flags] ENVIRONMENT PARAMETER VALUE\n  ssm put [flags] ENVIRONMENT PARAMETER --file FILE",
 		Short: "Store a parameter and its value in the AWS SSM parameter store",
 		Long:  putLong,
 		Args:  cobra.RangeArgs(2, 3),
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			return validateEnvironment(args[0])
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doPut(cmd.Context(), args)
 		},


### PR DESCRIPTION
Document the `--grep` option to the `kubectl-p` plugin in the README.

When using the `--brief` option of `ssm list`, don't add an empty line between each entry.

Name the `ENVIRONMENT` and `PARAMETER` argument names consistently between all the subcommands for the `ssm` utility.

Add error checking for the `ENVIRONMENT` parameter for all of the `ssm` sub-commands.