### PR TITLE
Use parallel routines for AWS SSM operations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,5 @@
   * Add JSON output for the `get` and `list` commands.
   * Handle getting and putting tags.
   * Implement `copy` command.
-  * Possibly use `golang.org/x/sync/errgroup` to run both GetParameter and DescribeParameter operations in parallel?
 * Improve / add tests for the AWS code once I work out how to mock AWS services.
 * Add --version flags to everything? Since they are all in the 1 repo have it use CalVer (YYYY.0M.0D) at build time perhaps?

--- a/ssm/cmd/get.go
+++ b/ssm/cmd/get.go
@@ -81,7 +81,7 @@ func doGet(ctx context.Context, args []string) error {
 
 	param := getSSMPath(args[0], args[1])
 
-	p, err := aws.SSMGet(ctx, ssmClient, param)
+	p, err := aws.SSMGet(ctx, ssmClient, param, getOpts.full)
 	if err != nil {
 		var notFound *types.ParameterNotFound
 		if errors.As(err, &notFound) {

--- a/ssm/cmd/put.go
+++ b/ssm/cmd/put.go
@@ -226,7 +226,7 @@ func getPutValue(args []string) (string, error) {
 func isPutValueUnchanged(
 	ctx context.Context, ssmClient *ssm.Client, param string, ssmParam aws.SSMParameter,
 ) (bool, error) {
-	p, err := aws.SSMGet(ctx, ssmClient, param)
+	p, err := aws.SSMGet(ctx, ssmClient, param, true)
 	if err != nil {
 		return false, fmt.Errorf("%w: %w", errGetSSMParameter, err)
 	}


### PR DESCRIPTION
Make use the `golang.org/x/sync/errgroup` module to use go routines to run some steps in parallel in the SSM functions in the `aws` module.

Modify the `aws.SSMList()` and `aws.SSMListSafeDecrypt()` functions so that a call to describe each parameter is not happening within the loop that fetches them. Instead, if the `--full` parameter was used, then after the parameters are fetched, go routines describe each parameter in parallel to fill in the extra parameter attributes. This removes a major bottleneck that my previous version had. A semaphore is used to allow up to 20 go routines to run in parallel to avoid overloading the AWS SSM API endpoint.

Have the `aws.SSMGet()` function use go routines to perform the `GetParameter()` and `DescribeParameter()` calls in parallel.

Add a boolean `describe` parameter to the `aws.SSMGet()` function to define if the parameter should be described to get extra attributes. Update all calls to the function accordingly. The `ssm get` command passes `getOpts.full` for this new parameter so that it won't waste resources fetching attributes that will not be shown to the user.

Capture errors from the calls to `SSMDescribeParameter()` properly.