### PR TITLE
Add util.MarshalWithFields() function

### DIFF
--- a/ssm/cmd/get.go
+++ b/ssm/cmd/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/jim-barber-he/go/aws"
+	"github.com/jim-barber-he/go/util"
 	"github.com/spf13/cobra"
 )
 
@@ -99,7 +100,12 @@ func doGet(ctx context.Context, args []string) error {
 		par.Print(false, getOpts.json)
 	} else {
 		if getOpts.json {
-			fmt.Printf("{\"value\": \"%s\"}\n", par.Value)
+			jsonData, err := util.MarshalWithFields(par, "value")
+			if err != nil {
+				return fmt.Errorf("failed to marshal parameter value to JSON: %w", err)
+			}
+
+			fmt.Println(string(jsonData))
 		} else {
 			fmt.Println(par.Value)
 		}

--- a/ssm/cmd/list.go
+++ b/ssm/cmd/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/jim-barber-he/go/aws"
+	"github.com/jim-barber-he/go/util"
 	"github.com/spf13/cobra"
 )
 
@@ -182,11 +183,22 @@ func displayDefault(param aws.SSMParameter) {
 
 // displayDefaultJSON is a helper function to display a parameter in default JSON format.
 func displayDefaultJSON(param aws.SSMParameter) {
+	var (
+		err      error
+		jsonData []byte
+	)
+
 	if listOpts.noValue {
-		fmt.Printf(`{"name":"%s","type":"%s"}`+"\n", param.Name, param.Type)
+		jsonData, err = util.MarshalWithFields(param, "name", "type")
 	} else {
-		fmt.Printf(`{"name":"%s","type":"%s","value":"%s"}`+"\n", param.Name, param.Type, param.Value)
+		jsonData, err = util.MarshalWithFields(param, "name", "type", "value")
 	}
+
+	if err != nil {
+		fmt.Printf("Error: failed to marshal parameter to JSON: %v\n", err)
+	}
+
+	fmt.Println(string(jsonData))
 }
 
 // displayDefaultText is a helper function to display a parameter in default text format.

--- a/util/util.go
+++ b/util/util.go
@@ -138,6 +138,27 @@ func LastSplitItem(str, splitChar string) string {
 	return ""
 }
 
+// MarshalWithFields marshals a struct to JSON keeping only the specified fields.
+func MarshalWithFields(v any, fields ...string) ([]byte, error) {
+	rawJSON, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(rawJSON, &m); err != nil {
+		return nil, err
+	}
+
+	// Create a new map with only the fields we want to keep.
+	filteredMap := make(map[string]any)
+	for _, field := range fields {
+		filteredMap[field] = m[field]
+	}
+
+	return json.Marshal(filteredMap)
+}
+
 // MarshalWithoutFields marshals a struct to JSON omitting one or more fields.
 func MarshalWithoutFields(v any, omitFields ...string) ([]byte, error) {
 	rawJSON, err := json.Marshal(v)


### PR DESCRIPTION
Add the `util.MarshalWithFields()` function to convert structs to JSON keeping only the desired fields.

Use it to produce JSON output in the `ssm get` and `ssm list` commands instead of hacking the JSON up via fmt.Printf statements.